### PR TITLE
feat(suggest-permissions): acknowledged findings と Review モード終了コードを追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Custom Claude Code skills by ikeisuke",
-    "version": "0.0.11"
+    "version": "0.0.12"
   },
   "plugins": [
     {

--- a/skills/suggest-permissions/SKILL.md
+++ b/skills/suggest-permissions/SKILL.md
@@ -8,7 +8,7 @@ description: >
   extracting common rules across multiple ghq-managed repositories.
   Also handles "review", "レビュー", "監査", "audit", "危険な設定" for
   auditing existing permission settings for dangerous configurations.
-argument-hint: "[--project {name}] [--days {N}] [--tool {name}] [--min-count {N}] [--consolidate {ghq-prefix}...] [--review [global|project|all]]"
+argument-hint: "[--project {name}] [--days {N}] [--tool {name}] [--min-count {N}] [--consolidate {ghq-prefix}...] [--review [global|project|all]] [--show-suppressed]"
 allowed-tools: Bash(python3 *suggest-permissions.py:*), Bash(python3 ~/.claude/plugins/cache/ikeisuke-skills/tools/*/skills/suggest-permissions/*), Bash(ghq *)
 ---
 
@@ -277,8 +277,72 @@ python3 /path/to/skills/suggest-permissions/scripts/suggest-permissions.py --rev
 |------|-------------|---------|
 | `--review` | 監査スコープ: `global`（グローバルのみ）, `project`（プロジェクトのみ）, `all`（両方） | all |
 | `--format` | `table` or `json` | table |
+| `--show-suppressed` | acknowledged findings で抑制された指摘も `(suppressed)` マーカー付きで表示 | false |
 
 `--project`, `--days`, `--session` 等の通常モードオプションは Review モードでは無視される。
+
+### 終了コード
+
+呼び出し側スクリプトから `--review && echo OK` のように成否判定するため、終了コードを以下に規定する:
+
+| 状態 | exit code |
+|------|-----------|
+| 抑制後のアクションが必要な指摘（CRITICAL/HIGH/MED）が **0 件** | `0` |
+| 抑制後のアクションが必要な指摘が **1 件以上** | `1` |
+| 設定ファイル破損・異常停止（例: `--review project` 指定時に `.claude/` がない） | `2` |
+
+LOW（推奨事項）と INFO（情報）は出力には現れるが、終了コードはゲートしない（対応は任意のため）。
+
+### Acknowledged findings（既知指摘の抑制）
+
+毎回検出される偽陽性の指摘は、プロジェクトの `.claude/settings.json` に登録して Review 出力から抑制できる:
+
+```json
+{
+  "suggestPermissions": {
+    "acknowledgedFindings": [
+      {
+        "pattern": "Bash(bash -n *)",
+        "severity": "CRITICAL",
+        "note": "シンタックスチェック専用（スクリプト非実行）",
+        "acknowledgedAt": "2026-04-18"
+      },
+      {
+        "pattern": "Bash(rm /tmp/aidlc-*)",
+        "severity": "HIGH",
+        "note": "一時ファイル限定のスコープ"
+      }
+    ]
+  }
+}
+```
+
+| フィールド | 必須 | 説明 |
+|-----------|------|------|
+| `pattern` | yes | 指摘対象ルール文字列に対する **glob パターン**（`fnmatch` 相当）。前後空白はトリムされる |
+| `severity` | yes | `CRITICAL` / `HIGH` / `MED` / `LOW` / `INFO`（大文字小文字不問） |
+| `note` | no | 抑制理由のメモ |
+| `acknowledgedAt` | no | 抑制日付（任意の文字列） |
+
+**マッチング**: `pattern` と `severity` の AND 条件。両方が一致したエントリで対応する findings を抑制する。
+
+**運用上の注意**: 抑制リストは「既知安全な偽陽性」のみに使う。本物のリスクを抑制すると重大な誤検出の見落としにつながるので、`note` には抑制理由を必ず書くこと。
+
+### 完了判定フローのリファレンス
+
+呼び出し側（CI / プロジェクトの完了基準等）で本スキルを成功条件に組み込む推奨パターン:
+
+```bash
+# テーブル出力で確認しつつ exit code で判定
+python3 /path/to/suggest-permissions.py --review && echo "permissions OK"
+
+# JSON で取り込む場合
+python3 /path/to/suggest-permissions.py --review --format json | jq '.remaining_issues == 0'
+```
+
+**プロジェクト Intent / 完了基準への書き方の例**:
+
+> `tools:suggest-permissions --review` が exit 0 で終了すること。偽陽性は `.claude/settings.json` の `suggestPermissions.acknowledgedFindings` に登録してレビューから除外する。
 
 ### 検出カテゴリと重要度
 

--- a/skills/suggest-permissions/SKILL.md
+++ b/skills/suggest-permissions/SKILL.md
@@ -293,6 +293,8 @@ python3 /path/to/skills/suggest-permissions/scripts/suggest-permissions.py --rev
 
 LOW（推奨事項）と INFO（情報）は出力には現れるが、終了コードはゲートしない（対応は任意のため）。
 
+`acknowledgedFindings` の JSON が破損している / セクションが配列でない 等の異常では、警告を stderr に出して suppression を無効化したうえで Review 自体は通常通り続行する（exit 2 にはならない）。これは「抑制ファイル不調で完了判定が落ちる」事態を避けるための設計。
+
 ### Acknowledged findings（既知指摘の抑制）
 
 毎回検出される偽陽性の指摘は、プロジェクトの `.claude/settings.json` に登録して Review 出力から抑制できる:
@@ -326,7 +328,12 @@ LOW（推奨事項）と INFO（情報）は出力には現れるが、終了コ
 
 **マッチング**: `pattern` と `severity` の AND 条件。両方が一致したエントリで対応する findings を抑制する。
 
-**運用上の注意**: 抑制リストは「既知安全な偽陽性」のみに使う。本物のリスクを抑制すると重大な誤検出の見落としにつながるので、`note` には抑制理由を必ず書くこと。
+**運用上の注意**:
+
+- 抑制リストは「既知安全な偽陽性」のみに使う。本物のリスクを抑制すると重大な誤検出の見落としにつながる。`note` には抑制理由を必ず書くこと。
+- `acknowledgedAt` を活用して抑制エントリの**鮮度**を追跡する。コードや設定が変わると抑制理由が古くなる場合があるので、定期的（例: 半年〜年次）に見直し、不要になったエントリは削除する。
+- `pattern` を緩めすぎない（例: `Bash(*)` のような全一致 glob は抑制の意味を失わせる）。スコープを最小に絞る。
+- 抑制を増やす前に、可能なら設定ファイル側を直す（`allow` から `ask` への移動、より狭いスコープへの変更等）。抑制は最終手段。
 
 ### 完了判定フローのリファレンス
 
@@ -336,8 +343,8 @@ LOW（推奨事項）と INFO（情報）は出力には現れるが、終了コ
 # テーブル出力で確認しつつ exit code で判定
 python3 /path/to/suggest-permissions.py --review && echo "permissions OK"
 
-# JSON で取り込む場合
-python3 /path/to/suggest-permissions.py --review --format json | jq '.remaining_issues == 0'
+# JSON で取り込む場合（jq -e で exit code を返す）
+python3 /path/to/suggest-permissions.py --review --format json | jq -e '.remaining_issues == 0' >/dev/null
 ```
 
 **プロジェクト Intent / 完了基準への書き方の例**:

--- a/skills/suggest-permissions/scripts/suggest-permissions.py
+++ b/skills/suggest-permissions/scripts/suggest-permissions.py
@@ -1127,7 +1127,8 @@ def main():
     args = parse_args()
 
     if args.review is not None:
-        return run_review(args) or 0
+        code = run_review(args)
+        return 0 if code is None else code
 
     if args.consolidate:
         run_consolidate(args)
@@ -1353,4 +1354,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main() or 0)
+    code = main()
+    sys.exit(0 if code is None else code)

--- a/skills/suggest-permissions/scripts/suggest-permissions.py
+++ b/skills/suggest-permissions/scripts/suggest-permissions.py
@@ -2,6 +2,7 @@
 """Collect tool usage patterns from Claude Code session history for permission rule suggestions."""
 
 import argparse
+import fnmatch
 import json
 import os
 import re
@@ -95,6 +96,8 @@ def parse_args():
     # Review mode
     parser.add_argument("--review", nargs="?", const="all", choices=["global", "project", "all"],
                         help="Review existing settings for dangerous configurations (default: all)")
+    parser.add_argument("--show-suppressed", action="store_true",
+                        help="Show acknowledged (suppressed) findings with a (suppressed) marker")
     # Consolidate mode
     parser.add_argument("--consolidate", nargs="+", metavar="GHQ_PREFIX",
                         help="Consolidate common rules from repos matching ghq prefix(es)")
@@ -657,6 +660,94 @@ def check_ask_overrides_allow(project_rules, global_rules):
     return findings
 
 
+def load_acknowledged_findings(cwd):
+    """Load acknowledgedFindings from project-scoped .claude/settings.json.
+
+    Returns a list of normalized entries: [{pattern, severity, note, acknowledgedAt}, ...].
+
+    Failure modes (per Issue #26):
+    - settings.json missing → return []
+    - JSON parse error or top-level value not an object → warn, return []
+    - acknowledgedFindings missing or not a list → warn (only when not a list), return []
+    - individual entry missing pattern / invalid severity → warn, skip that entry
+    - note / acknowledgedAt missing or wrong type → silently treat as empty (optional fields)
+    """
+    path = Path(cwd) / ".claude" / "settings.json"
+    if not path.exists():
+        return []
+    try:
+        raw_text = path.read_text()
+    except OSError as e:
+        print(f"warning: {path}: {e}; suppression disabled", file=sys.stderr)
+        return []
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as e:
+        print(f"warning: {path}: JSON parse error: {e}; suppression disabled", file=sys.stderr)
+        return []
+    if not isinstance(data, dict):
+        return []
+    section = data.get("suggestPermissions")
+    if section is None:
+        return []
+    if not isinstance(section, dict):
+        print(f"warning: {path}: suggestPermissions is not an object; suppression disabled", file=sys.stderr)
+        return []
+    raw_list = section.get("acknowledgedFindings")
+    if raw_list is None:
+        return []
+    if not isinstance(raw_list, list):
+        print(f"warning: {path}: suggestPermissions.acknowledgedFindings is not an array; suppression disabled", file=sys.stderr)
+        return []
+
+    entries = []
+    for i, item in enumerate(raw_list):
+        if not isinstance(item, dict):
+            print(f"warning: acknowledgedFindings[{i}] is not an object; skipping", file=sys.stderr)
+            continue
+        pattern = item.get("pattern")
+        if not isinstance(pattern, str) or not pattern.strip():
+            print(f"warning: acknowledgedFindings[{i}]: missing or invalid 'pattern'; skipping", file=sys.stderr)
+            continue
+        severity = item.get("severity")
+        if not isinstance(severity, str) or severity.strip().upper() not in REVIEW_SEVERITY:
+            print(f"warning: acknowledgedFindings[{i}]: missing or invalid 'severity'; skipping", file=sys.stderr)
+            continue
+        note = item.get("note", "")
+        if not isinstance(note, str):
+            note = ""
+        ack_at = item.get("acknowledgedAt", "")
+        if not isinstance(ack_at, str):
+            ack_at = ""
+        entries.append({
+            "pattern": pattern.strip(),
+            "severity": severity.strip().upper(),
+            "note": note,
+            "acknowledgedAt": ack_at,
+        })
+    return entries
+
+
+def is_finding_acknowledged(finding, acknowledged):
+    """Match a finding against acknowledgedFindings entries.
+
+    Matching rule (per Issue #26):
+    - severity equality (case-insensitive)
+    - pattern matches finding["rule"] via fnmatch (glob); finding rule is whitespace-trimmed
+    Returns the matching entry dict or None.
+    """
+    rule = (finding.get("rule") or "").strip()
+    sev = (finding.get("severity") or "").strip().upper()
+    if not rule:
+        return None
+    for entry in acknowledged:
+        if entry["severity"] != sev:
+            continue
+        if fnmatch.fnmatchcase(rule, entry["pattern"]):
+            return entry
+    return None
+
+
 def check_missing_protections(all_deny, all_ask):
     """Check for recommended deny rules that are missing."""
     findings = []
@@ -671,7 +762,13 @@ def check_missing_protections(all_deny, all_ask):
 
 
 def run_review(args):
-    """Review existing permission settings for dangerous configurations."""
+    """Review existing permission settings for dangerous configurations.
+
+    Returns an exit code:
+        0 — no remaining (active, non-INFO) findings
+        1 — at least one remaining (active, non-INFO) finding
+        2 — abnormal stop (e.g. project scope requested but no .claude/ directory)
+    """
     scope = args.review  # "global", "project", or "all"
     cwd = os.getcwd()
 
@@ -689,7 +786,7 @@ def run_review(args):
             project_rules = empty_rules.copy()
             if scope == "project":
                 print("No .claude/ directory found in current project.", file=sys.stderr)
-                sys.exit(1)
+                return 2
     else:
         project_rules = empty_rules.copy()
 
@@ -724,9 +821,33 @@ def run_review(args):
     # Sort by severity
     findings.sort(key=lambda f: REVIEW_SEVERITY.index(f["severity"]))
 
-    # Summary counts
-    summary = {s: 0 for s in REVIEW_SEVERITY}
+    # Apply acknowledged findings suppression (project-scoped settings.json only)
+    acknowledged = load_acknowledged_findings(cwd)
     for f in findings:
+        ack = is_finding_acknowledged(f, acknowledged) if acknowledged else None
+        if ack:
+            f["suppressed"] = True
+            f["acknowledged_pattern"] = ack["pattern"]
+            f["acknowledged_note"] = ack["note"]
+            f["acknowledged_at"] = ack["acknowledgedAt"]
+        else:
+            f["suppressed"] = False
+
+    active_findings = [f for f in findings if not f["suppressed"]]
+    suppressed_findings = [f for f in findings if f["suppressed"]]
+    suppressed_count = len(suppressed_findings)
+
+    # Remaining count drives the exit code: only actionable severities (CRITICAL/HIGH/MED)
+    # gate the exit code. LOW is recommended/optional and INFO is informational, so they
+    # surface in output but do not fail the run. This lets `--review && echo OK` work
+    # without forcing every project to add every recommended deny rule.
+    actionable = {"CRITICAL", "HIGH", "MED"}
+    remaining_issues = sum(1 for f in active_findings if f["severity"] in actionable)
+
+    # Summary counts (for displayed findings)
+    display_findings = findings if args.show_suppressed else active_findings
+    summary = {s: 0 for s in REVIEW_SEVERITY}
+    for f in display_findings:
         summary[f["severity"]] += 1
 
     if args.format == "json":
@@ -735,11 +856,13 @@ def run_review(args):
                 "global": {k: dict(sorted(v.items())) if isinstance(v, dict) else sorted(v) for k, v in global_rules.items()},
                 "project": {k: dict(sorted(v.items())) if isinstance(v, dict) else sorted(v) for k, v in project_rules.items()},
             },
-            "findings": findings,
+            "findings": display_findings,
             "summary": summary,
+            "suppressed_count": suppressed_count,
+            "remaining_issues": remaining_issues,
         }
         print(json.dumps(output, indent=2, ensure_ascii=False))
-        return
+        return 0 if remaining_issues == 0 else 1
 
     # Table format
     scope_label = {"global": "global only", "project": "project only", "all": "global + project"}
@@ -753,17 +876,22 @@ def run_review(args):
         print(f"  Project (.claude/): {len(project_rules['deny'])} deny, "
               f"{len(project_rules['ask'])} ask, {len(project_rules['allow'])} allow")
 
-    if not findings:
-        print("\nNo issues found. Settings look good.")
-        return
+    if not display_findings:
+        if suppressed_count > 0 and not args.show_suppressed:
+            print(f"\nNo active issues. {suppressed_count} acknowledged finding(s) suppressed.")
+            print("(Use --show-suppressed to inspect them.)")
+        else:
+            print("\nNo issues found. Settings look good.")
+        return 0 if remaining_issues == 0 else 1
 
-    print(f"\nFindings ({sum(v for k, v in summary.items() if k != 'INFO')} issues):\n")
+    issue_count = sum(v for k, v in summary.items() if k != "INFO")
+    print(f"\nFindings ({issue_count} issues):\n")
 
     fmt = "  {:<10} {:<45} {}"
     print(fmt.format("SEV", "RULE", "MESSAGE"))
     print("  " + "-" * 108)
 
-    for f in findings:
+    for f in display_findings:
         # Build source label: e.g. [project/settings.json/allow] or [global/allow]
         if f["source"] != "-":
             file_part = f["file"].replace(".json", "") + "/" if f["file"] else ""
@@ -771,18 +899,27 @@ def run_review(args):
         else:
             source_label = ""
         rule_col = f"{f['rule'][:30]}  {source_label}" if f["rule"] else "-"
-        print(fmt.format(f["severity"], rule_col[:45], f["message"][:80]))
+        msg = f["message"]
+        if f.get("suppressed"):
+            msg = f"(suppressed) {msg}"
+        print(fmt.format(f["severity"], rule_col[:45], msg[:80]))
 
     print()
     summary_parts = [f"{summary[s]} {s.lower()}" for s in REVIEW_SEVERITY if summary[s] > 0]
     print(f"Summary: {', '.join(summary_parts)}")
 
-    # Show recommendations for HIGH+ findings
-    high_findings = [f for f in findings if f["severity"] in ("CRITICAL", "HIGH") and f["recommendation"]]
+    if suppressed_count > 0 and not args.show_suppressed:
+        print(f"\nℹ {suppressed_count}件の既知指摘を抑制しました（詳細は --show-suppressed）")
+
+    # Show recommendations for HIGH+ findings (active only)
+    high_findings = [f for f in active_findings
+                     if f["severity"] in ("CRITICAL", "HIGH") and f["recommendation"]]
     if high_findings:
         print("\nRecommendations:")
         for f in high_findings:
             print(f"  {f['rule']}: {f['recommendation']}")
+
+    return 0 if remaining_issues == 0 else 1
 
 
 def list_ghq_repos(prefixes):
@@ -990,12 +1127,11 @@ def main():
     args = parse_args()
 
     if args.review is not None:
-        run_review(args)
-        return
+        return run_review(args) or 0
 
     if args.consolidate:
         run_consolidate(args)
-        return
+        return 0
 
     claude_projects = Path.home() / ".claude" / "projects"
     if not claude_projects.exists():
@@ -1213,7 +1349,8 @@ def main():
 
     new_count = sum(1 for s in suggestions if not s["already_allowed"])
     print(f"\nTotal: {len(suggestions)} patterns, {new_count} new (not yet in allow list)")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main() or 0)

--- a/skills/suggest-permissions/tests/test_suppression.py
+++ b/skills/suggest-permissions/tests/test_suppression.py
@@ -1,0 +1,268 @@
+"""Tests for acknowledged-findings suppression and review exit codes."""
+
+import argparse
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import importlib
+sp = importlib.import_module("suggest-permissions")
+
+
+def _make_finding(severity="CRITICAL", rule="Bash(bash -n *)"):
+    return sp.make_finding(severity, "test-cat", rule, "global", "allow", "msg")
+
+
+class TestIsFindingAcknowledged(unittest.TestCase):
+    def test_exact_match(self):
+        ack = [{"pattern": "Bash(bash -n *)", "severity": "CRITICAL", "note": "", "acknowledgedAt": ""}]
+        self.assertIsNotNone(sp.is_finding_acknowledged(_make_finding(), ack))
+
+    def test_glob_match(self):
+        ack = [{"pattern": "Bash(rm /tmp/*)", "severity": "HIGH", "note": "", "acknowledgedAt": ""}]
+        self.assertIsNotNone(sp.is_finding_acknowledged(
+            _make_finding("HIGH", "Bash(rm /tmp/aidlc-foo)"), ack))
+
+    def test_severity_must_match(self):
+        ack = [{"pattern": "Bash(bash -n *)", "severity": "HIGH", "note": "", "acknowledgedAt": ""}]
+        self.assertIsNone(sp.is_finding_acknowledged(_make_finding("CRITICAL"), ack))
+
+    def test_pattern_must_match(self):
+        ack = [{"pattern": "Bash(rm *)", "severity": "CRITICAL", "note": "", "acknowledgedAt": ""}]
+        self.assertIsNone(sp.is_finding_acknowledged(_make_finding(), ack))
+
+    def test_empty_ack_list(self):
+        self.assertIsNone(sp.is_finding_acknowledged(_make_finding(), []))
+
+
+class TestLoadAcknowledgedFindings(unittest.TestCase):
+    def _write(self, tmp, content):
+        claude_dir = Path(tmp) / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        (claude_dir / "settings.json").write_text(content)
+
+    def test_no_settings_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(sp.load_acknowledged_findings(tmp), [])
+
+    def test_no_section(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, json.dumps({"permissions": {"allow": []}}))
+            self.assertEqual(sp.load_acknowledged_findings(tmp), [])
+
+    def test_valid_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, json.dumps({
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"pattern": "Bash(bash -n *)", "severity": "CRITICAL", "note": "syntax check"},
+                        {"pattern": "Bash(rm /tmp/aidlc-*)", "severity": "high",
+                         "acknowledgedAt": "2026-04-18"},
+                    ]
+                }
+            }))
+            entries = sp.load_acknowledged_findings(tmp)
+            self.assertEqual(len(entries), 2)
+            self.assertEqual(entries[0]["severity"], "CRITICAL")
+            self.assertEqual(entries[1]["severity"], "HIGH")  # normalized to upper
+            self.assertEqual(entries[0]["note"], "syntax check")
+            self.assertEqual(entries[1]["acknowledgedAt"], "2026-04-18")
+
+    def test_invalid_severity_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, json.dumps({
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"pattern": "Bash(bash -n *)", "severity": "BOGUS"},
+                        {"pattern": "Bash(rm *)", "severity": "HIGH"},
+                    ]
+                }
+            }))
+            err = io.StringIO()
+            with redirect_stderr(err):
+                entries = sp.load_acknowledged_findings(tmp)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["pattern"], "Bash(rm *)")
+            self.assertIn("severity", err.getvalue())
+
+    def test_missing_pattern_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, json.dumps({
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"severity": "HIGH"},
+                        {"pattern": "   ", "severity": "HIGH"},
+                        {"pattern": "Bash(ok *)", "severity": "HIGH"},
+                    ]
+                }
+            }))
+            err = io.StringIO()
+            with redirect_stderr(err):
+                entries = sp.load_acknowledged_findings(tmp)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["pattern"], "Bash(ok *)")
+
+    def test_not_a_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, json.dumps({
+                "suggestPermissions": {"acknowledgedFindings": "oops"}
+            }))
+            err = io.StringIO()
+            with redirect_stderr(err):
+                entries = sp.load_acknowledged_findings(tmp)
+            self.assertEqual(entries, [])
+            self.assertIn("not an array", err.getvalue())
+
+    def test_broken_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            (Path(tmp) / ".claude" / "settings.json").write_text("{not-json")
+            err = io.StringIO()
+            with redirect_stderr(err):
+                entries = sp.load_acknowledged_findings(tmp)
+            self.assertEqual(entries, [])
+            self.assertIn("JSON parse error", err.getvalue())
+            self.assertIn("suppression disabled", err.getvalue())
+
+    def test_optional_fields_wrong_type(self):
+        """note / acknowledgedAt with wrong types should be silently coerced to ''."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, json.dumps({
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"pattern": "Bash(bash -n *)", "severity": "CRITICAL",
+                         "note": 123, "acknowledgedAt": True}
+                    ]
+                }
+            }))
+            entries = sp.load_acknowledged_findings(tmp)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["note"], "")
+            self.assertEqual(entries[0]["acknowledgedAt"], "")
+
+
+class TestRunReviewExitCodes(unittest.TestCase):
+    """Integration tests for run_review() exit codes and suppression output."""
+
+    def _args(self, **overrides):
+        ns = argparse.Namespace(
+            review="project", format="table", show_suppressed=False,
+            project=None, session=None, days=30, tool=None,
+            min_count=3, show_all=False, consolidate=None, min_repos=2,
+        )
+        for k, v in overrides.items():
+            setattr(ns, k, v)
+        return ns
+
+    def _run_in_dir(self, tmp, args):
+        cwd = os.getcwd()
+        os.chdir(tmp)
+        out = io.StringIO()
+        err = io.StringIO()
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                code = sp.run_review(args)
+        finally:
+            os.chdir(cwd)
+        return code, out.getvalue(), err.getvalue()
+
+    def test_exit_0_when_no_findings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            (Path(tmp) / ".claude" / "settings.json").write_text(json.dumps({
+                "permissions": {"allow": ["Bash(ls:*)"]}
+            }))
+            code, out, _ = self._run_in_dir(tmp, self._args())
+            self.assertEqual(code, 0)
+
+    def test_exit_1_when_remaining_findings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            (Path(tmp) / ".claude" / "settings.json").write_text(json.dumps({
+                "permissions": {"allow": ["Bash(bash -n *)"]}  # CRITICAL never-allow
+            }))
+            code, out, _ = self._run_in_dir(tmp, self._args())
+            self.assertEqual(code, 1)
+            self.assertIn("CRITICAL", out)
+
+    def test_exit_0_when_all_findings_suppressed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            (Path(tmp) / ".claude" / "settings.json").write_text(json.dumps({
+                "permissions": {"allow": ["Bash(bash -n *)"]},
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"pattern": "Bash(bash -n *)", "severity": "CRITICAL",
+                         "note": "syntax check only"}
+                    ]
+                }
+            }))
+            code, out, _ = self._run_in_dir(tmp, self._args())
+            self.assertEqual(code, 0)
+            self.assertIn("1件の既知指摘を抑制しました", out)
+            self.assertNotIn("(suppressed)", out)
+
+    def test_show_suppressed_displays_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            (Path(tmp) / ".claude" / "settings.json").write_text(json.dumps({
+                "permissions": {"allow": ["Bash(bash -n *)"]},
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"pattern": "Bash(bash -n *)", "severity": "CRITICAL"}
+                    ]
+                }
+            }))
+            code, out, _ = self._run_in_dir(tmp, self._args(show_suppressed=True))
+            # Even with --show-suppressed, exit code reflects active remaining
+            self.assertEqual(code, 0)
+            self.assertIn("(suppressed)", out)
+
+    def test_exit_2_when_project_scope_no_claude_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code, _, err = self._run_in_dir(tmp, self._args(review="project"))
+            self.assertEqual(code, 2)
+            self.assertIn("No .claude/", err)
+
+    def test_glob_suppression(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            # rm is HIGH (destructive); pattern with glob should match
+            (Path(tmp) / ".claude" / "settings.json").write_text(json.dumps({
+                "permissions": {"allow": ["Bash(rm /tmp/aidlc-*)"]},
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"pattern": "Bash(rm /tmp/*)", "severity": "HIGH"}
+                    ]
+                }
+            }))
+            code, out, _ = self._run_in_dir(tmp, self._args())
+            self.assertEqual(code, 0)
+            self.assertIn("既知指摘を抑制", out)
+
+    def test_json_output_includes_remaining(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".claude").mkdir()
+            (Path(tmp) / ".claude" / "settings.json").write_text(json.dumps({
+                "permissions": {"allow": ["Bash(bash -n *)"]},
+                "suggestPermissions": {
+                    "acknowledgedFindings": [
+                        {"pattern": "Bash(bash -n *)", "severity": "CRITICAL"}
+                    ]
+                }
+            }))
+            code, out, _ = self._run_in_dir(tmp, self._args(format="json"))
+            self.assertEqual(code, 0)
+            data = json.loads(out)
+            self.assertEqual(data["remaining_issues"], 0)
+            self.assertEqual(data["suppressed_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/suggest-permissions/tests/test_suppression.py
+++ b/skills/suggest-permissions/tests/test_suppression.py
@@ -161,8 +161,16 @@ class TestRunReviewExitCodes(unittest.TestCase):
         return ns
 
     def _run_in_dir(self, tmp, args):
+        """Run run_review with cwd and HOME both pointing into the tmp sandbox.
+
+        Overriding HOME isolates global ~/.claude/ rules from the test fixture,
+        so that future tests using scope='all' don't pick up the real user's
+        global settings on the CI host.
+        """
         cwd = os.getcwd()
+        prev_home = os.environ.get("HOME")
         os.chdir(tmp)
+        os.environ["HOME"] = tmp
         out = io.StringIO()
         err = io.StringIO()
         try:
@@ -170,6 +178,10 @@ class TestRunReviewExitCodes(unittest.TestCase):
                 code = sp.run_review(args)
         finally:
             os.chdir(cwd)
+            if prev_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = prev_home
         return code, out.getvalue(), err.getvalue()
 
     def test_exit_0_when_no_findings(self):


### PR DESCRIPTION
Closes #26

## Summary

- Review モードの偽陽性指摘を `.claude/settings.json` の `suggestPermissions.acknowledgedFindings` で抑制可能に。`pattern` (glob) と `severity` の AND 条件でマッチ。
- `--show-suppressed` フラグで抑制済み指摘を `(suppressed)` マーカー付きで表示。
- 終了コードを規定: actionable 残指摘 (CRITICAL/HIGH/MED) 0件で 0、1件以上で 1、project スコープで `.claude/` 不在の異常停止で 2。LOW/INFO は出力に表示するが exit code をゲートしない。
- 失敗モード: 設定ファイル不在 / JSON 破損 / セクションが配列でない 等は警告表示して suppression 無効化、Review 自体は従来通り続行。
- SKILL.md に終了コード仕様、acknowledgedFindings の書き方、完了判定フローのリファレンスを追加。

## Test plan

- [x] `python3 -m unittest discover -s tests` で 101 件すべて pass
- [x] スモークテスト: 偽陽性が抑制されると exit 0、actionable 指摘が残ると exit 1、`--review project` で `.claude/` 不在時に exit 2
- [x] `skill-lint` で warn なし
- [x] セルフコードレビュー（ローカル diff）
- [ ] `codex review --base main`（Codex の usage limit に達したため未実行。limit 解除後に追加で実施予定）