### PR TITLE
feat(cross-platform-review): macOS/Linux 互換レビュースキルを新規追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Custom Claude Code skills by ikeisuke",
-    "version": "0.0.11"
+    "version": "0.0.12"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,7 @@
       "source": "./",
       "strict": false,
       "skills": [
+        "./skills/cross-platform-review",
         "./skills/gh-api-fallback",
         "./skills/git-attribution",
         "./skills/jj-workflow",

--- a/skills/cross-platform-review/SKILL.md
+++ b/skills/cross-platform-review/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: cross-platform-review
+description: >
+  Reviews shell scripts and config files for macOS / Linux (incl. WSL2)
+  cross-platform compatibility. Triggers on "cross-platform-review",
+  "クロスプラットフォームレビュー", "macOS Linux 互換", "両対応レビュー",
+  "BSD GNU 差", or requests to audit dotfiles / setup scripts for portability.
+  Catches portability issues that shellcheck / `bash -n` cannot (BSD vs GNU
+  command flags, path differences, OS branching asymmetry).
+argument-hint: "[--base {ref}] [--paths {glob}...]"
+allowed-tools: Bash(git diff:*), Bash(git rev-parse:*), Bash(git show:*), Bash(git ls-files:*)
+---
+
+# Cross-Platform Review
+
+シェルスクリプト・設定ファイルの **macOS と Linux (WSL2 含む) 両対応** をレビューする。
+`shellcheck` や `bash -n` では検出できない「片方の OS でしか動かない / 挙動が変わる」コードを差分から検出し、互換性の指摘と修正案を提示する。
+
+## チェックリスト
+
+```
+タスク進捗：
+- [ ] Step 1: 差分取得（base ブランチとの比較 or 指定範囲）
+- [ ] Step 2: 対象ファイルの抽出（.sh / .zsh / Brewfile / setup スクリプト等）
+- [ ] Step 3: 観点リストに沿って差分を点検
+- [ ] Step 4: 互換性問題と修正案を提示
+```
+
+## Step 1: 差分の取得
+
+引数なしの場合は `main` との差分を対象にする。`--base <ref>` で比較ベースを変更可。
+
+```bash
+# デフォルト: main ブランチとの差分
+git diff main...HEAD
+
+# ベース指定
+git diff <base>...HEAD
+
+# 範囲指定（特定コミットのみレビュー）
+git diff <ref>~..<ref>
+```
+
+リポジトリのデフォルトブランチが `main` 以外の場合は、`git symbolic-ref refs/remotes/origin/HEAD` で確認する。
+
+## Step 2: 対象ファイルの抽出
+
+差分から以下のパターンに該当するファイルを抽出する:
+
+| カテゴリ | パターン |
+|---------|---------|
+| シェルスクリプト | `*.sh`, `*.bash`, `*.zsh` |
+| シェル設定 | `.zshrc`, `.bashrc`, `.bash_profile`, `.zprofile`, `.zshenv` |
+| zsh モジュール | `zsh/**/*.zsh` |
+| パッケージ定義 | `Brewfile`, `Brewfile.local`, `Brewfile.lock.json` |
+| セットアップ | `setup.sh`, `install.sh`, `bootstrap.sh`, `Makefile`（シェル呼び出しがある場合） |
+| Git hooks | `.git/hooks/*`, `hooks/*` |
+
+`--paths` 引数で対象を絞り込み可能（glob を渡す）。
+
+抽出件数が 0 なら「シェル系の差分なし。レビュー不要」と表示して終了。
+
+## Step 3: 観点リストに沿った点検
+
+[references/checklist.md](references/checklist.md) のチェックリストに沿って各差分を点検する:
+
+- **BSD / GNU コマンド差**（`sed`, `date`, `stat`, `mktemp`, `readlink`, `find`, `grep`, `awk`）
+- **環境差**（パス、macOS 専用コマンド、Linux 専用コマンド、WSL2 特有処理）
+- **Brewfile / setup スクリプト**（`OS.mac?` / `OS.linux?` ブロック対称性）
+- **zsh モジュール構成**（`zsh/os/darwin.zsh` / `linux.zsh` 対称性、`$OSTYPE` 分岐の網羅）
+
+各指摘には以下を付ける:
+
+| 要素 | 内容 |
+|------|------|
+| 重要度 | `BLOCKER`（片方で動かない）/ `HIGH`（挙動差）/ `MED`（警告で済む）/ `LOW`（推奨） |
+| ファイル + 行番号 | `path/to/file.sh:42` |
+| 検出した観点 | 例: 「BSD `sed -i` には引数 `''` が必須」 |
+| 修正案 | 互換性のあるコード例 |
+
+## Step 4: 結果の提示
+
+重要度別にまとめて出力:
+
+```
+Cross-Platform Review (base: main, 3 files):
+
+BLOCKER (1):
+  setup.sh:42  BSD sed -i には引数 '' が必須
+    現状: sed -i 's/foo/bar/' file
+    修正案: sed -i '' 's/foo/bar/' file   # macOS
+            sed -i '' -e 's/foo/bar/' file # 両対応の安全策（GNU でも動く）
+
+HIGH (2):
+  zsh/os/darwin.zsh:15  Linux 側 (zsh/os/linux.zsh) に対応コード無し（非対称）
+    ...
+
+MED (1):
+  Brewfile:8  if OS.mac? ブロックの追加項目に対応する OS.linux? エントリ無し
+    ...
+
+Summary: 1 blocker, 2 high, 1 med
+```
+
+指摘ゼロなら「Cross-Platform Review: 互換性問題は検出されませんでした」と表示。
+
+## スコープ外
+
+- 自動修正（指摘までで止める。ユーザーが手で修正する）
+- macOS / Linux で実コマンドを動かす検証（観点ベースの静的レビュー）
+- Windows ネイティブ環境（Cygwin / MSYS2 等）のサポート
+- `shellcheck` / `bash -n` の代替（補完であって置換ではない）
+
+## Examples
+
+User: `/cross-platform-review`
+→ `main` ブランチとの差分から対象ファイルを抽出し、BSD/GNU コマンド差・パス差・OS 分岐の対称性を点検。
+
+User: `/cross-platform-review --base origin/main`
+→ リモート main との差分を対象にレビュー。
+
+User: `/cross-platform-review --paths 'setup.sh' 'Brewfile'`
+→ 指定パターンに一致するファイルのみレビュー。
+
+## Troubleshooting
+
+### 観点リストの追加
+
+実利用で見落としが見つかったら [references/checklist.md](references/checklist.md) に観点を追記する。観点リストは初期セットから始めて、運用で育てる。
+
+### shellcheck / bash -n との関係
+
+- `shellcheck` / `bash -n` は構文・典型バグを検出（OS 依存差は対象外）
+- 本スキルは **OS 依存差** を検出（構文は対象外）
+- 両方を CI に組み込むのが理想
+
+## Rules
+
+- 静的レビューに徹する。コマンドを実際に動かして検証しない。
+- 修正案は **必ず両対応の例** を示す（macOS のみ / Linux のみの片対応コードは避ける）。
+- 観点リストにない問題を見つけても指摘してよいが、再発防止のためレビュー後に [references/checklist.md](references/checklist.md) への追記を提案する。

--- a/skills/cross-platform-review/SKILL.md
+++ b/skills/cross-platform-review/SKILL.md
@@ -8,7 +8,7 @@ description: >
   Catches portability issues that shellcheck / `bash -n` cannot (BSD vs GNU
   command flags, path differences, OS branching asymmetry).
 argument-hint: "[--base {ref}] [--paths {glob}...]"
-allowed-tools: Bash(git diff:*), Bash(git rev-parse:*), Bash(git show:*), Bash(git ls-files:*)
+allowed-tools: Bash(git diff:*), Bash(git rev-parse:*), Bash(git show:*), Bash(git ls-files:*), Bash(git symbolic-ref:*), Read
 ---
 
 # Cross-Platform Review

--- a/skills/cross-platform-review/references/checklist.md
+++ b/skills/cross-platform-review/references/checklist.md
@@ -97,16 +97,17 @@ macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン
   - 結果: `find ... | xargs cmd` で 0 件のとき、Linux では `cmd` が空引数で 1 回呼ばれ、macOS では呼ばれない
   - 注意: `-0` (NUL 区切り) は **delimiter を変えるだけ**で空入力ガードではない。`find ... -print0 | xargs -0 cmd` も Linux では空入力時に `cmd` が呼ばれる
   - NG（Linux で空入力時に意図せず実行）: `find . -name '*.tmp' | xargs rm`
-  - **両対応の推奨形 1**: `find -exec ... +` を使い xargs を経由しない（`find` は 0 件で utility を呼ばないため両 OS で安全）
+  - **両対応の推奨形**: `find -exec ... +` を使い xargs を経由しない（POSIX find は 0 件で utility を呼ばないため両 OS で安全。空白・改行を含むファイル名でも破綻しない）
     ```bash
     find . -name '*.tmp' -exec rm {} +
     ```
-  - **両対応の推奨形 2**: 前段で空チェックする
+  - xargs を必ず使う場合は NUL 区切りで空白・改行に対応し、空チェックを **明示的に**入れる（`-0` 自体は空入力ガードではない点に注意）:
     ```bash
-    files=$(find . -name '*.tmp')
-    [ -n "$files" ] && printf '%s\n' "$files" | xargs rm
+    # GNU/BSD 両対応: -print0 + xargs -0 + 件数チェック
+    matches=$(find . -name '*.tmp' -print0 | tr -d -c '\0' | wc -c)
+    [ "$matches" -gt 0 ] && find . -name '*.tmp' -print0 | xargs -0 rm
     ```
-  - 別解: GNU 専用環境では `xargs -r`、Brew で `findutils` (GNU coreutils 系) を入れて `gxargs -r` を使う
+  - 別解: クロスプラットフォーム不要なら GNU 環境で `xargs -r`、または Brew の `findutils` から `gxargs -r` を使う
 - **`-d` (delimiter)**: GNU 専用。両対応では `-0`（NUL 区切り）+ `find -print0` / `tr` でパイプ
 
 ### `ls`

--- a/skills/cross-platform-review/references/checklist.md
+++ b/skills/cross-platform-review/references/checklist.md
@@ -22,17 +22,21 @@ macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン
 ## 1. BSD / GNU コマンド差
 
 ### `sed`
-- **`sed -i`**: macOS は引数 `''` が必須。GNU は不要
+- **`sed -i`**: macOS BSD は `-i` の直後に **拡張子引数が必須**（空文字列でもよい）。GNU は引数なしを許容
   - NG: `sed -i 's/foo/bar/' file`（macOS で「extra argument」エラー）
-  - OK 両対応: `sed -i.bak 's/foo/bar/' file && rm file.bak`（バックアップ拡張子を明示）
-  - OK 両対応: `sed -i '' -e 's/foo/bar/' file`（macOS 用）／ `sed -i'' -e 's/foo/bar/' file`（一部 GNU で動く）
-  - 推奨: `gsed`（GNU sed）を Brewfile で導入し、両対応スクリプトでは GNU 互換を選ぶ
+  - NG（GNU でしか動かない）: `sed -i'' -e 's/foo/bar/' file`（BSD は `-i` の引数として `''` を取れずエラー）
+  - **両対応の推奨形**: バックアップ拡張子を明示し、後で消す
+    ```bash
+    sed -i.bak 's/foo/bar/' file && rm -f file.bak
+    ```
+  - macOS 専用なら: `sed -i '' 's/foo/bar/' file`（`-i` と `''` の間に空白が必要）
+  - 別解: `gsed`（GNU sed）を Brewfile で導入し、両対応スクリプトでは GNU 互換を選ぶ
 - **拡張正規表現**: BSD は `-E`、GNU は `-r` だが、GNU は `-E` も受け付ける → **常に `-E` を使う**
 - **`\s`, `\b` 等の Perl 拡張**: BSD では非対応。POSIX 文字クラス（`[[:space:]]` 等）に置き換える
 
 ### `date`
-- **`-d` フラグ**: GNU 専用（任意の日付文字列をパース）。macOS BSD `date` は `-d` を別の意味（DST 設定）で使う
-  - NG（macOS で動かない）: `date -d '1 day ago'`
+- **`-d` フラグ**: GNU 専用（任意の日付文字列をパース）。macOS BSD `date` は `-d` を受け付けず usage エラーになる
+  - NG（macOS で usage エラー）: `date -d '1 day ago'`
   - OK 両対応: macOS は `date -v-1d`、GNU は `date -d '1 day ago'` → OS 判定して分岐
   - 推奨: 簡単な日付なら `date +%Y-%m-%d` だけで済むよう設計を見直す
 - **タイムゾーン指定**: macOS は `TZ=Asia/Tokyo date`、GNU も同形式で動く（共通）
@@ -45,21 +49,27 @@ macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン
 - もしくは OS 分岐で `stat` のフラグを切り替える
 
 ### `mktemp`
-- **テンプレート**: macOS は引数なし or `-t prefix` で `$TMPDIR` 配下に作成。GNU は `mktemp /tmp/foo.XXXXXX` のように **テンプレートが必須**
-  - NG（macOS で意図と違う挙動）: `mktemp` だけ
-  - OK 両対応: `mktemp /tmp/myapp.XXXXXX`（X が 6 個以上のテンプレートを明示）
+- **テンプレート**: macOS BSD は引数なし / `-t prefix` で `$TMPDIR` 配下にファイル作成（場所は OS 依存）。GNU は `mktemp /tmp/foo.XXXXXX` のように **テンプレートが必須**
+  - 両 OS で動くが作成先パスが揃わない: `mktemp` 単独は macOS では `$TMPDIR/tmp.XXXXXXXX` を生成、GNU は usage エラー
+  - **両対応の推奨形**: フルパステンプレートを明示する
+    ```bash
+    mktemp /tmp/myapp.XXXXXX  # X は 6 個以上
+    ```
+  - 補足: GNU の `mktemp -t prefix.XXXXXX` は GNU 専用挙動（テンプレート必須かつ `-t` で `$TMPDIR` 経由）。macOS BSD の `-t prefix` とはセマンティクスが異なる
 - **`-d` (ディレクトリ作成)**: 両対応
 
 ### `readlink`
-- **`-f` フラグ**: macOS BSD `readlink` には **`-f` がない**（一部新しめの macOS は対応）
-  - NG: `readlink -f script.sh`（古い macOS で失敗）
-  - OK 両対応:
+- **`-f` フラグ**: macOS BSD `readlink` の `-f` は環境依存（macOS 12 以降は `-f` をサポート、それ以前の Mac では未対応）。CI / 古い環境を前提にするなら避ける
+  - NG（古い macOS / 一部の最小環境で失敗）: `readlink -f script.sh`
+  - **両対応の推奨形**:
     ```bash
-    # Python 経由
+    # 1) Python 経由（最も移植性が高い）
     python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
-    # or grealink (coreutils)
-    grealink -f "$1"
-    # or 自前ループ
+
+    # 2) coreutils の greadlink（Brew で `coreutils` を入れると greadlink が使える）
+    greadlink -f "$1"
+
+    # 3) シェルだけで完結させる自前ループ
     target="$1"
     while [ -L "$target" ]; do target=$(readlink "$target"); done
     ```
@@ -81,8 +91,18 @@ macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン
   - 推奨: ポータブル POSIX awk の範囲で書く。GNU 専用機能を使うなら `gawk` を明示
 
 ### `xargs`
-- **`-r` (`--no-run-if-empty`)**: GNU 専用。BSD は空入力でもコマンド実行しない（デフォルトで安全）
-- **`-d` (delimiter)**: GNU 専用 → `tr` でパイプして対応
+- **`-r` (`--no-run-if-empty`)**: GNU 専用フラグ。macOS BSD `xargs` には `-r` がなく、**空入力でもコマンドを 1 回実行する**（POSIX 準拠の挙動）
+  - NG（macOS で空入力時に意図せず実行）: `find . -name '*.tmp' | xargs rm`
+  - **両対応の推奨形**: 空入力ガードを明示
+    ```bash
+    # find の -empty 判定 or 一時ファイル経由
+    find . -name '*.tmp' -print0 | xargs -0 -I{} rm {}
+    # もしくは前段で空チェック
+    files=$(find . -name '*.tmp')
+    [ -n "$files" ] && echo "$files" | xargs rm
+    ```
+  - 別解: GNU coreutils の `gxargs` を Brewfile で導入し `-r` を使う
+- **`-d` (delimiter)**: GNU 専用。両対応では `-0`（NUL 区切り）+ `find -print0` / `tr` でパイプして対応
 
 ### `ls`
 - **色オプション**: GNU は `--color=auto`、BSD は `-G`
@@ -119,7 +139,7 @@ macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン
 ### システムパス
 - `/usr/local/bin`: macOS Intel デフォルト、Linux にも存在
 - `/opt/homebrew/bin`: macOS Apple Silicon
-- `/usr/bin/local`: 一部 Linux ディストリ（タイポ注意）
+- 注意: `/usr/bin/local` は **実在しないタイポパターン**。`/usr/local/bin` の打ち間違いとして混入していないか確認
 
 ### ハードコードされたパスの検出
 - `/Users/...` (macOS) や `/home/...` (Linux) を直書きしている箇所は基本的に NG

--- a/skills/cross-platform-review/references/checklist.md
+++ b/skills/cross-platform-review/references/checklist.md
@@ -91,17 +91,20 @@ macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン
   - 推奨: ポータブル POSIX awk の範囲で書く。GNU 専用機能を使うなら `gawk` を明示
 
 ### `xargs`
-- **`-r` (`--no-run-if-empty`)**: GNU 専用フラグ。macOS BSD `xargs` には `-r` がなく、**空入力でもコマンドを 1 回実行する**（POSIX 準拠の挙動）
-  - NG（macOS で空入力時に意図せず実行）: `find . -name '*.tmp' | xargs rm`
-  - **両対応の推奨形**: 空入力ガードを明示
+- **`-r` (`--no-run-if-empty`)**: GNU 専用フラグ。空入力時の挙動は OS で **逆向きに非対称**:
+  - **GNU `xargs`**: 空入力でも utility を **1 回実行**する（POSIX-2017 では implementation-defined だが GNU はこの挙動）。`-r` で抑制可能
+  - **macOS BSD `xargs`**: 空入力では utility を実行しない（man page: "the FreeBSD version of xargs does not run the utility argument on empty input"）。`-r` は互換性のため受け付けるが no-op
+  - 結果: `find ... | xargs cmd` で 0 件のとき、Linux では `cmd` が空引数で 1 回呼ばれ、macOS では呼ばれない
+  - NG（Linux で空入力時に意図せず実行）: `find . -name '*.tmp' | xargs rm`
+  - **両対応の推奨形**: NUL 区切りを使う（`xargs -0` は 0 件入力で utility を呼ばない仕様で両 OS 共通）
     ```bash
-    # find の -empty 判定 or 一時ファイル経由
-    find . -name '*.tmp' -print0 | xargs -0 -I{} rm {}
-    # もしくは前段で空チェック
+    find . -name '*.tmp' -print0 | xargs -0 rm
+    ```
+  - 別解: 前段で空チェックして両 OS で挙動を揃える
+    ```bash
     files=$(find . -name '*.tmp')
     [ -n "$files" ] && echo "$files" | xargs rm
     ```
-  - 別解: GNU coreutils の `gxargs` を Brewfile で導入し `-r` を使う
 - **`-d` (delimiter)**: GNU 専用。両対応では `-0`（NUL 区切り）+ `find -print0` / `tr` でパイプして対応
 
 ### `ls`

--- a/skills/cross-platform-review/references/checklist.md
+++ b/skills/cross-platform-review/references/checklist.md
@@ -92,20 +92,22 @@ macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン
 
 ### `xargs`
 - **`-r` (`--no-run-if-empty`)**: GNU 専用フラグ。空入力時の挙動は OS で **逆向きに非対称**:
-  - **GNU `xargs`**: 空入力でも utility を **1 回実行**する（POSIX-2017 では implementation-defined だが GNU はこの挙動）。`-r` で抑制可能
+  - **GNU `xargs`**: 空入力でも utility を **1 回実行**する（POSIX-2017 では implementation-defined だが GNU はこの挙動）。GNU info manual: "By default, xargs runs the command once even if there is no input". `-r` で抑制可能
   - **macOS BSD `xargs`**: 空入力では utility を実行しない（man page: "the FreeBSD version of xargs does not run the utility argument on empty input"）。`-r` は互換性のため受け付けるが no-op
   - 結果: `find ... | xargs cmd` で 0 件のとき、Linux では `cmd` が空引数で 1 回呼ばれ、macOS では呼ばれない
+  - 注意: `-0` (NUL 区切り) は **delimiter を変えるだけ**で空入力ガードではない。`find ... -print0 | xargs -0 cmd` も Linux では空入力時に `cmd` が呼ばれる
   - NG（Linux で空入力時に意図せず実行）: `find . -name '*.tmp' | xargs rm`
-  - **両対応の推奨形**: NUL 区切りを使う（`xargs -0` は 0 件入力で utility を呼ばない仕様で両 OS 共通）
+  - **両対応の推奨形 1**: `find -exec ... +` を使い xargs を経由しない（`find` は 0 件で utility を呼ばないため両 OS で安全）
     ```bash
-    find . -name '*.tmp' -print0 | xargs -0 rm
+    find . -name '*.tmp' -exec rm {} +
     ```
-  - 別解: 前段で空チェックして両 OS で挙動を揃える
+  - **両対応の推奨形 2**: 前段で空チェックする
     ```bash
     files=$(find . -name '*.tmp')
-    [ -n "$files" ] && echo "$files" | xargs rm
+    [ -n "$files" ] && printf '%s\n' "$files" | xargs rm
     ```
-- **`-d` (delimiter)**: GNU 専用。両対応では `-0`（NUL 区切り）+ `find -print0` / `tr` でパイプして対応
+  - 別解: GNU 専用環境では `xargs -r`、Brew で `findutils` (GNU coreutils 系) を入れて `gxargs -r` を使う
+- **`-d` (delimiter)**: GNU 専用。両対応では `-0`（NUL 区切り）+ `find -print0` / `tr` でパイプ
 
 ### `ls`
 - **色オプション**: GNU は `--color=auto`、BSD は `-G`

--- a/skills/cross-platform-review/references/checklist.md
+++ b/skills/cross-platform-review/references/checklist.md
@@ -1,0 +1,219 @@
+# Cross-Platform Review Checklist
+
+macOS (BSD) と Linux (GNU, WSL2 含む) で挙動が変わる代表パターン。
+差分に該当する記述があれば BLOCKER / HIGH / MED に分類して指摘する。
+
+## 目次
+
+1. [BSD / GNU コマンド差](#1-bsd--gnu-コマンド差)
+2. [シェル組み込みの差](#2-シェル組み込みの差)
+3. [パスの違い](#3-パスの違い)
+4. [macOS 専用コマンド](#4-macos-専用コマンド)
+5. [Linux 専用コマンド](#5-linux-専用コマンド)
+6. [WSL2 特有の処理](#6-wsl2-特有の処理)
+7. [Brewfile / セットアップスクリプトの対称性](#7-brewfile--セットアップスクリプトの対称性)
+8. [zsh モジュール構成（dotfiles 想定）](#8-zsh-モジュール構成dotfiles-想定)
+9. [シェバン (`#!`)](#9-シェバン-)
+10. [ファイルシステム差](#10-ファイルシステム差)
+11. [重要度の判定基準](#重要度の判定基準)
+
+---
+
+## 1. BSD / GNU コマンド差
+
+### `sed`
+- **`sed -i`**: macOS は引数 `''` が必須。GNU は不要
+  - NG: `sed -i 's/foo/bar/' file`（macOS で「extra argument」エラー）
+  - OK 両対応: `sed -i.bak 's/foo/bar/' file && rm file.bak`（バックアップ拡張子を明示）
+  - OK 両対応: `sed -i '' -e 's/foo/bar/' file`（macOS 用）／ `sed -i'' -e 's/foo/bar/' file`（一部 GNU で動く）
+  - 推奨: `gsed`（GNU sed）を Brewfile で導入し、両対応スクリプトでは GNU 互換を選ぶ
+- **拡張正規表現**: BSD は `-E`、GNU は `-r` だが、GNU は `-E` も受け付ける → **常に `-E` を使う**
+- **`\s`, `\b` 等の Perl 拡張**: BSD では非対応。POSIX 文字クラス（`[[:space:]]` 等）に置き換える
+
+### `date`
+- **`-d` フラグ**: GNU 専用（任意の日付文字列をパース）。macOS BSD `date` は `-d` を別の意味（DST 設定）で使う
+  - NG（macOS で動かない）: `date -d '1 day ago'`
+  - OK 両対応: macOS は `date -v-1d`、GNU は `date -d '1 day ago'` → OS 判定して分岐
+  - 推奨: 簡単な日付なら `date +%Y-%m-%d` だけで済むよう設計を見直す
+- **タイムゾーン指定**: macOS は `TZ=Asia/Tokyo date`、GNU も同形式で動く（共通）
+
+### `stat`
+- **フォーマット指定子の差**:
+  - BSD: `stat -f '%z' file`（サイズ）
+  - GNU: `stat -c '%s' file`
+- 両対応: `wc -c < file` でサイズ取得、`ls -l` を `awk` でパースする等、`stat` を避ける
+- もしくは OS 分岐で `stat` のフラグを切り替える
+
+### `mktemp`
+- **テンプレート**: macOS は引数なし or `-t prefix` で `$TMPDIR` 配下に作成。GNU は `mktemp /tmp/foo.XXXXXX` のように **テンプレートが必須**
+  - NG（macOS で意図と違う挙動）: `mktemp` だけ
+  - OK 両対応: `mktemp /tmp/myapp.XXXXXX`（X が 6 個以上のテンプレートを明示）
+- **`-d` (ディレクトリ作成)**: 両対応
+
+### `readlink`
+- **`-f` フラグ**: macOS BSD `readlink` には **`-f` がない**（一部新しめの macOS は対応）
+  - NG: `readlink -f script.sh`（古い macOS で失敗）
+  - OK 両対応:
+    ```bash
+    # Python 経由
+    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
+    # or grealink (coreutils)
+    grealink -f "$1"
+    # or 自前ループ
+    target="$1"
+    while [ -L "$target" ]; do target=$(readlink "$target"); done
+    ```
+
+### `find`
+- **`-regex`**: BSD と GNU で正規表現方言が違う
+  - GNU: デフォルトは emacs 風、`-regextype posix-extended` で ERE
+  - BSD: 常に basic regex、`-E` で ERE
+- **`-printf`**: GNU 専用。BSD には無し → `-exec stat ...` 等で代替
+
+### `grep`
+- **`-P` (PCRE)**: GNU 拡張。BSD `grep` は非対応
+  - NG: `grep -P '\d+' file`
+  - OK: `grep -E '[0-9]+' file`（ERE で代替できることが多い）
+- **`-r` の挙動差**: GNU は隠しファイルも含む、BSD はバージョン依存。明示的に `--include` / `--exclude` で制御
+
+### `awk`
+- **GNU 拡張（`gensub`, `gsub` の戻り値, `length` の引数）**: BSD `awk`（`nawk`）では動かない
+  - 推奨: ポータブル POSIX awk の範囲で書く。GNU 専用機能を使うなら `gawk` を明示
+
+### `xargs`
+- **`-r` (`--no-run-if-empty`)**: GNU 専用。BSD は空入力でもコマンド実行しない（デフォルトで安全）
+- **`-d` (delimiter)**: GNU 専用 → `tr` でパイプして対応
+
+### `ls`
+- **色オプション**: GNU は `--color=auto`、BSD は `-G`
+- 推奨: `eza` / `lsd` 等のクロスプラットフォームツールに置き換える
+
+### `ps`
+- **`-o tty=`**: 出力形式が macOS と Linux で違う（macOS は `ttys003`、Linux は `pts/3`）
+- 解析する場合は OS 判定で分岐
+
+---
+
+## 2. シェル組み込みの差
+
+### `read`
+- **`-i` (default value)**: bash 4 以降のみ。macOS デフォルト bash は 3.x → 動かない
+- **`-t` (timeout)**: 両対応だが、tty チェックの挙動差あり
+
+### `[[ ... ]]` の `=~`
+- 正規表現エンジンの差（BSD vs GNU）。両対応では POSIX `case ... esac` の方が安全
+
+### `local` / `declare`
+- macOS bash 3.x では `declare -A`（連想配列）が動かない。bash 4+ または zsh で書く
+
+---
+
+## 3. パスの違い
+
+### Homebrew prefix
+- macOS Intel: `/usr/local`
+- macOS Apple Silicon: `/opt/homebrew`
+- Linux: `/home/linuxbrew/.linuxbrew`
+- 取得: `brew --prefix`（インストール済みなら）または `$(brew --prefix)/bin` を `PATH` に追加する
+
+### システムパス
+- `/usr/local/bin`: macOS Intel デフォルト、Linux にも存在
+- `/opt/homebrew/bin`: macOS Apple Silicon
+- `/usr/bin/local`: 一部 Linux ディストリ（タイポ注意）
+
+### ハードコードされたパスの検出
+- `/Users/...` (macOS) や `/home/...` (Linux) を直書きしている箇所は基本的に NG
+- `~`, `$HOME`, `$XDG_CONFIG_HOME` を使う
+
+---
+
+## 4. macOS 専用コマンド
+
+WSL2 / Linux 側で代替手段を用意しているか確認:
+
+| macOS 専用 | Linux 代替 |
+|-----------|-----------|
+| `pbcopy` / `pbpaste` | `xclip -selection clipboard`, `xsel`, `wl-copy` (Wayland), WSL は `clip.exe` |
+| `osascript` | 代替なし（macOS 限定機能。OS 分岐で skip） |
+| `defaults` | 代替なし（macOS の plist 操作。OS 分岐で skip） |
+| `open` | `xdg-open` (Linux), `wslview` (WSL2) |
+| `say` | `espeak` (Linux), 代替なしのケース多 |
+
+---
+
+## 5. Linux 専用コマンド
+
+macOS 側で代替手段を用意しているか確認:
+
+| Linux 専用 | macOS 代替 |
+|-----------|-----------|
+| `apt`, `apt-get`, `yum`, `dnf` | `brew` |
+| `systemctl`, `service` | `launchctl`（用途が限定的） |
+| `xdg-open` | `open` |
+| `xdg-mime` | `duti` (Homebrew) |
+
+---
+
+## 6. WSL2 特有の処理
+
+- **WSL2 検出**: `uname -r` の結果に `WSL2` が含まれるか、`/proc/version` を見る
+  ```bash
+  if grep -qi microsoft /proc/version 2>/dev/null; then
+      # WSL 環境
+  fi
+  ```
+- **`/mnt/c/` 系のパス**: Windows ファイルシステムへのアクセス。パフォーマンス低下に注意
+- **クリップボード**: `clip.exe`（コピー）/ `powershell.exe Get-Clipboard`（ペースト）
+
+---
+
+## 7. Brewfile / セットアップスクリプトの対称性
+
+### `if OS.mac?` / `if OS.linux?` ブロック
+- 片方の OS で `brew` パッケージを追加したら、もう片方に **同等のものが必要か検討する**
+- macOS 専用 GUI アプリ（`cask`）は Linux 側で対応するアプリを `brew install` できる場合がある
+- Linux 側で apt 等を別途使うなら、`Brewfile` ではなく別のセットアップステップに移す
+
+### CI / ローカルの両対応
+- `setup.sh` の冒頭で `OS=$(uname -s)` を取得し、case 文で分岐するパターンが標準
+- ステップ間で「macOS では成功、Linux では未テスト」のような片対応が無いか確認
+
+---
+
+## 8. zsh モジュール構成（dotfiles 想定）
+
+### `zsh/os/darwin.zsh` / `zsh/os/linux.zsh` の対称性
+- `darwin.zsh` で alias / function / env を追加したら、Linux 側に対応する記述が必要か検討
+- Linux 側で取得できないコマンド（`pbcopy` 等）への alias は darwin 専用に隔離
+
+### 共通モジュール内での OS 分岐
+- 共通モジュール（例: `zsh/modules/git.zsh`）で OS 依存処理を書く場合、`[[ "$OSTYPE" == darwin* ]]` 等で確実に分岐する
+- 片方の分岐だけ書いて他方が空になっていないかチェック
+
+---
+
+## 9. シェバン (`#!`)
+
+- **`#!/bin/bash`**: macOS デフォルト bash は 3.x、Linux は 4+ → bash 4+ 機能は動かない
+  - 推奨: bash 4+ に依存するなら Brewfile で `bash` を追加し `#!/usr/bin/env bash` で `$PATH` から拾う
+- **`#!/bin/sh`**: Linux では多くが dash、macOS は bash 互換の sh → POSIX 範囲で書く
+- **`#!/usr/bin/env bash`**: 推奨。`$PATH` 上の bash を使う
+
+---
+
+## 10. ファイルシステム差
+
+- **大文字小文字**: macOS デフォルト APFS は **case-insensitive**、Linux ext4 は **case-sensitive** → ファイル名違いの import 等で破綻する
+- **改行コード**: WSL2 で git の autocrlf が効くと CRLF になることがある。`.gitattributes` で制御
+- **パーミッション**: macOS の execute bit が WSL2 経由で消えることがある
+
+---
+
+## 重要度の判定基準
+
+| 重要度 | 判定 |
+|--------|------|
+| BLOCKER | 片方の OS でエラー終了する（実行不可能） |
+| HIGH | 片方の OS で意図と違う動作をする（silent な誤動作） |
+| MED | 警告は出るが動く、または OS 判定漏れの片対応 |
+| LOW | 改善推奨（より移植性の高い書き方が存在） |


### PR DESCRIPTION
Closes #28

## Summary

- シェルスクリプト・設定ファイルの **macOS と Linux (WSL2 含む) 両対応** を静的レビューする新スキル。`/cross-platform-review` で起動。
- `git diff` から対象ファイル（`.sh` / `.zsh` / Brewfile / setup スクリプト等）を抽出し、references/checklist.md の観点リストに沿って点検。
- 観点（初期セット）: BSD vs GNU コマンド差（sed/date/stat/mktemp/readlink/find/grep/awk/xargs）、Homebrew prefix、macOS/Linux 専用コマンド、WSL2 特有処理、Brewfile/zsh モジュールの対称性、シェバン、ファイルシステム差。
- 各指摘に重要度（BLOCKER/HIGH/MED/LOW）、ファイル+行番号、修正案を付ける。
- 自動修正は行わない静的レビュー。`shellcheck` / `bash -n` の補完。

## Test plan

- [x] `skill-lint` で warn なし
- [x] marketplace.json に cross-platform-review を登録
- [x] checklist.md に目次を追加
- [ ] 実利用（dotfiles リポジトリで実行）で観点リストの抜けを確認
- [ ] `codex review --base main`（Codex の usage limit に達したため未実行。limit 解除後に追加で実施予定）