### PR TITLE
docs(README): スキル一覧の更新

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Custom Claude Code skills by ikeisuke",
-    "version": "0.0.12"
+    "version": "0.0.13"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Custom skills for [Claude Code](https://claude.com/claude-code).
 
 | Skill | Description |
 |-------|-------------|
+| [cross-platform-review](./skills/cross-platform-review/) | Review shell scripts and config files for macOS / Linux (incl. WSL2) cross-platform compatibility |
+| [gh-api-fallback](./skills/gh-api-fallback/) | Reference for substituting `gh api` (REST/GraphQL) when `gh` subcommands fail due to insufficient token scopes |
 | [git-attribution](./skills/git-attribution/) | Manage Claude Code's git attribution (Co-Authored-By) per repository |
+| [history-append](./skills/history-append/) | Generate and insert changelog entries into HISTORY.md / CHANGELOG.md from `git diff --staged` |
 | [jj-workflow](./skills/jj-workflow/) | jj (Jujutsu) version control workflow guide for co-location mode |
-| [session-title](./skills/session-title/) | Set terminal tab title and iTerm2 badge for session identification (macOS) |
+| [session-title](./skills/session-title/) | Set terminal tab title and badge for session identification (macOS / Linux / WSL2) |
 | [skill-lint](./skills/skill-lint/) | Check skills against official best practices and report violations |
 | [suggest-permissions](./skills/suggest-permissions/) | Suggest permission auto-approval rules with deep argument/flag analysis and risk assessment |
 | [translate-permissions](./skills/translate-permissions/) | Translate Claude Code permission settings to Kiro CLI custom agent configuration |


### PR DESCRIPTION
## Summary

README のスキル一覧に未掲載だったものを追加し、説明が古いものを更新。

- `cross-platform-review` を追加（PR #31 で新規追加）
- `gh-api-fallback` を追加（PR #25 で追加されていたが README 反映漏れ）
- `history-append` を追加（PR #30 で新規追加）
- `session-title` の説明を Linux/WSL2 対応反映 (PR #24)

## Test plan

- [x] README をプレビューしてスキル一覧表示を確認
- [x] アルファベット順を維持