### PR TITLE
ci(bump-version): skills/marketplace 以外の変更で bump をスキップ

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,12 +15,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Check if relevant files changed
+        id: paths
+        run: |
+          git fetch origin main
+          base_sha=$(git merge-base origin/main HEAD)
+          changed=$(git diff --name-only "$base_sha" HEAD)
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -qE '^(skills/|\.claude-plugin/)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Relevant changes detected → bump enabled"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No skill/marketplace changes → bump skipped (success status will still be posted)"
+          fi
 
       - name: Check if version already bumped
         id: check
+        if: steps.paths.outputs.relevant == 'true'
         run: |
           file=".claude-plugin/marketplace.json"
-          git fetch origin main
           base_version=$(git show origin/main:"$file" | jq -r '.metadata.version')
           head_version=$(jq -r '.metadata.version' "$file")
           if [ "$base_version" != "$head_version" ]; then
@@ -32,7 +49,7 @@ jobs:
           fi
 
       - name: Bump patch version in marketplace.json
-        if: steps.check.outputs.skip == 'false'
+        if: steps.paths.outputs.relevant == 'true' && steps.check.outputs.skip == 'false'
         run: |
           file=".claude-plugin/marketplace.json"
           current=$(jq -r '.metadata.version' "$file")
@@ -42,7 +59,7 @@ jobs:
           echo "Bumped version: $current -> $new_version"
 
       - name: Commit and push
-        if: steps.check.outputs.skip == 'false'
+        if: steps.paths.outputs.relevant == 'true' && steps.check.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -54,9 +71,16 @@ jobs:
       - name: Set success status on HEAD
         run: |
           sha=$(git rev-parse HEAD)
+          if [ "${{ steps.paths.outputs.relevant }}" = "false" ]; then
+            description="No skill/marketplace changes — bump skipped"
+          elif [ "${{ steps.check.outputs.skip }}" = "true" ]; then
+            description="Version already bumped manually"
+          else
+            description="Version bump completed"
+          fi
           gh api "repos/${{ github.repository }}/statuses/${sha}" \
             -f state=success \
             -f context="Bump patch version" \
-            -f description="Version bump completed"
+            -f description="${description}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ Custom skills for [Claude Code](https://claude.com/claude-code).
 
 | Skill | Description |
 |-------|-------------|
+| [cross-platform-review](./skills/cross-platform-review/) | Review shell scripts and config files for macOS / Linux (incl. WSL2) cross-platform compatibility |
+| [gh-api-fallback](./skills/gh-api-fallback/) | Reference for substituting `gh api` (REST/GraphQL) when `gh` subcommands fail due to insufficient token scopes |
 | [git-attribution](./skills/git-attribution/) | Manage Claude Code's git attribution (Co-Authored-By) per repository |
+| [history-append](./skills/history-append/) | Generate and insert changelog entries into HISTORY.md / CHANGELOG.md from `git diff --staged` |
 | [jj-workflow](./skills/jj-workflow/) | jj (Jujutsu) version control workflow guide for co-location mode |
-| [session-title](./skills/session-title/) | Set terminal tab title and iTerm2 badge for session identification (macOS) |
+| [session-title](./skills/session-title/) | Set terminal tab title and badge for session identification (macOS / Linux / WSL2) |
 | [skill-lint](./skills/skill-lint/) | Check skills against official best practices and report violations |
 | [suggest-permissions](./skills/suggest-permissions/) | Suggest permission auto-approval rules with deep argument/flag analysis and risk assessment |
 | [translate-permissions](./skills/translate-permissions/) | Translate Claude Code permission settings to Kiro CLI custom agent configuration |


### PR DESCRIPTION
## Summary

main 向けの全 PR で `Bump patch version` workflow が走り、README や workflow 自体の修正だけでも version が上がってしまう問題を修正。

- `skills/**` または `.claude-plugin/**` に変更がある場合のみ bump 処理を実行
- それ以外は bump をスキップし、required check として success status のみ post（`paths-ignore` を使うと workflow が起動せず required check が永久に揃わずマージブロックされるため、内部分岐方式を採用）
- success status の description で「skipped (no relevant changes) / already bumped / bumped」を区別

## Test plan

- [x] このPR自体が docs/ci しか触らず bump スキップで成功 status になることを確認（マージ前に self-test）
- [ ] マージ後、次の README 系 PR で version が上がらないことを確認

## Note

このPR自体は `.github/workflows/` のみ変更なので、新ロジックに従うと bump がスキップされる想定。