### PR TITLE
docs(CLAUDE): 新ブランチ作成前の git checkout main を必須化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 
 main ブランチは直接 push 不可。変更は PR 経由でマージすること。
 
+新しい feature/fix ブランチを作る前は **必ず `git checkout main && git pull --ff-only`** を挟むこと。別の feature ブランチを base にしたまま `git checkout -b` すると、別 PR の作業差分が新ブランチに混入し、PR レビューと履歴を汚す（実例: PR #33 に PR #32 の README コミットが意図せず含まれてマージされた）。
+
 ## バージョン管理
 
 PRが main にマージされると、GitHub Actions が `.claude-plugin/marketplace.json` の `metadata.version` のパッチバージョンを自動で上げる。手動でのバージョン変更は不要。


### PR DESCRIPTION
## Summary

PR #33 のマージ時、別ブランチ (`chore/readme-update-skills`) を base にしたまま `git checkout -b chore/bump-version-paths-filter` したため、PR #32 の README コミット (77d00c7) が PR #33 に意図せず含まれて main にマージされた。結果として PR #32 はクローズ廃止、main は workflow + README が両方反映された状態。

再発防止として、新ブランチ作成前に `git checkout main && git pull --ff-only` を挟むルールを CLAUDE.md に明記する。

## Test plan

- [x] このPR自体が新 workflow で bump スキップされることを確認（CLAUDE.md は skills/marketplace 配下ではない）